### PR TITLE
Change timestamp value of directories to time.Unix(0, 0)

### DIFF
--- a/s3_file.go
+++ b/s3_file.go
@@ -91,7 +91,7 @@ func (f *File) Readdir(n int) ([]os.FileInfo, error) {
 	}
 	var fis = make([]os.FileInfo, 0, len(output.CommonPrefixes)+len(output.Contents))
 	for _, subfolder := range output.CommonPrefixes {
-		fis = append(fis, NewFileInfo(filepath.Base("/"+*subfolder.Prefix), true, 0, time.Time{}))
+		fis = append(fis, NewFileInfo(filepath.Base("/"+*subfolder.Prefix), true, 0, time.Unix(0, 0)))
 	}
 	for _, fileObject := range output.Contents {
 		if hasTrailingSlash(*fileObject.Key) {

--- a/s3_fs.go
+++ b/s3_fs.go
@@ -272,7 +272,7 @@ func (fs Fs) statDirectory(name string) (os.FileInfo, error) {
 			Err:  os.ErrNotExist,
 		}
 	}
-	return NewFileInfo(filepath.Base(name), true, 0, time.Time{}), nil
+	return NewFileInfo(filepath.Base(name), true, 0, time.Unix(0, 0)), nil
 }
 
 // Chmod doesn't exists in S3 but could be implemented by analyzing ACLs


### PR DESCRIPTION
When used from fclairamb/ftpserver, Some ftp client implementations treat directories as invalid if timestamp value can't be converted to unix timestamp.