### PR TITLE
Re-applying Sanitize path names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         if: matrix.lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45
+          version: v1.43
 
       # Install Go
       - name: Setup go

--- a/s3_file.go
+++ b/s3_file.go
@@ -75,9 +75,9 @@ func (f *File) Readdir(n int) ([]os.FileInfo, error) {
 	if name != "" && !strings.HasSuffix(name, "/") {
 		name += "/"
 	}
-	output, err := f.fs.s3API.ListObjectsV2(&s3.ListObjectsV2Input{
+	output, err := f.fs.S3API.ListObjectsV2(&s3.ListObjectsV2Input{
 		ContinuationToken: f.readdirContinuationToken,
-		Bucket:            aws.String(f.fs.bucket),
+		Bucket:            aws.String(f.fs.Bucket),
 		Prefix:            aws.String(name),
 		Delimiter:         aws.String("/"),
 		MaxKeys:           aws.Int64(int64(n)),
@@ -213,6 +213,10 @@ func (f *File) Close() error {
 // It returns the number of bytes read and an error, if any.
 // EOF is signaled by a zero count with err set to io.EOF.
 func (f *File) Read(p []byte) (int, error) {
+	if f.streamRead == nil {
+		return 0, io.EOF
+	}
+
 	n, err := f.streamRead.Read(p)
 
 	if err == nil {
@@ -304,12 +308,12 @@ func (f *File) openWriteStream() error {
 	f.streamWriteCloseErr = make(chan error)
 	f.streamWrite = writer
 
-	uploader := s3manager.NewUploader(f.fs.session)
+	uploader := s3manager.NewUploader(f.fs.Session)
 	uploader.Concurrency = 1
 
 	go func() {
 		input := &s3manager.UploadInput{
-			Bucket: aws.String(f.fs.bucket),
+			Bucket: aws.String(f.fs.Bucket),
 			Key:    aws.String(f.name),
 			Body:   reader,
 		}
@@ -347,8 +351,8 @@ func (f *File) openReadStream(startAt int64) error {
 		streamRange = aws.String(fmt.Sprintf("bytes=%d-%d", startAt, f.cachedInfo.Size()))
 	}
 
-	resp, err := f.fs.s3API.GetObject(&s3.GetObjectInput{
-		Bucket: aws.String(f.fs.bucket),
+	resp, err := f.fs.S3API.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(f.fs.Bucket),
 		Key:    aws.String(f.name),
 		Range:  streamRange,
 	})

--- a/s3_test.go
+++ b/s3_test.go
@@ -485,7 +485,7 @@ func TestBadConnection(t *testing.T) {
 	fs := __getS3Fs(t)
 
 	// Let's mess-up the config
-	fs.session.Config.Endpoint = aws.String("http://broken")
+	fs.Session.Config.Endpoint = aws.String("http://broken")
 
 	t.Run("Read", func(t *testing.T) {
 		// We will fail here because we are checking if the file exists and its type
@@ -674,8 +674,8 @@ func TestContentType(t *testing.T) {
 
 		// And we check the resulting content-type
 		for fileName, mimeType := range fileToMime {
-			resp, err := fs.s3API.GetObject(&s3.GetObjectInput{
-				Bucket: aws.String(fs.bucket),
+			resp, err := fs.S3API.GetObject(&s3.GetObjectInput{
+				Bucket: aws.String(fs.Bucket),
 				Key:    aws.String(fileName),
 			})
 			req.NoError(err)
@@ -687,8 +687,8 @@ func TestContentType(t *testing.T) {
 		_, err := fs.Create("create.png")
 		req.NoError(err)
 
-		resp, err := fs.s3API.GetObject(&s3.GetObjectInput{
-			Bucket: aws.String(fs.bucket),
+		resp, err := fs.S3API.GetObject(&s3.GetObjectInput{
+			Bucket: aws.String(fs.Bucket),
 			Key:    aws.String("create.png"),
 		})
 		req.NoError(err)
@@ -704,8 +704,8 @@ func TestContentType(t *testing.T) {
 		testCreateFile(t, fs, "custom-write", "content")
 
 		for _, name := range []string{"custom-create", "custom-write"} {
-			resp, err := fs.s3API.GetObject(&s3.GetObjectInput{
-				Bucket: aws.String(fs.bucket),
+			resp, err := fs.S3API.GetObject(&s3.GetObjectInput{
+				Bucket: aws.String(fs.Bucket),
 				Key:    aws.String(name),
 			})
 			req.NoError(err)
@@ -732,8 +732,8 @@ func TestFileProps(t *testing.T) {
 		testCreateFile(t, fs, "write", "content")
 
 		for _, name := range []string{"create", "write"} {
-			resp, err := fs.s3API.GetObject(&s3.GetObjectInput{
-				Bucket: aws.String(fs.bucket),
+			resp, err := fs.S3API.GetObject(&s3.GetObjectInput{
+				Bucket: aws.String(fs.Bucket),
 				Key:    aws.String(name),
 			})
 			req.NoError(err)


### PR DESCRIPTION
Re-applying #435:

In particular, guards against the use of backslash
delimited filepaths as used on Windows.

This situation can occur when nesting s3.Fs inside an
afero.BasePathFs which will process paths using filepath
package.

On Windows calls to MkdirAll will use Windows
paths and will create backslash paths on S3 which is
undesirable.

Fixes https://github.com/fclairamb/afero-s3/issues/434

Signed-off-by: Jack Mordaunt [jackmordaunt.dev@gmail.com](mailto:jackmordaunt.dev@gmail.com)