### PR TITLE
fix: extract repeated "stat" string into opStat constant

### DIFF
--- a/s3_fs.go
+++ b/s3_fs.go
@@ -23,6 +23,9 @@ import (
 
 // https://aws.github.io/aws-sdk-go-v2/docs/migrating/
 
+// opStat is the os.PathError.Op value reported by Stat-related failures.
+const opStat = "stat"
+
 // Fs is an FS object backed by S3.
 type Fs struct {
 	FileProps *UploadedFileProperties // FileProps define the file properties we want to set for all new files
@@ -267,7 +270,7 @@ func (fs *Fs) Stat(name string) (os.FileInfo, error) {
 		}
 
 		return FileInfo{}, &os.PathError{
-			Op:   "stat",
+			Op:   opStat,
 			Path: name,
 			Err:  err,
 		}
@@ -287,14 +290,14 @@ func (fs *Fs) statDirectory(name string) (os.FileInfo, error) {
 	})
 	if err != nil {
 		return FileInfo{}, &os.PathError{
-			Op:   "stat",
+			Op:   opStat,
 			Path: name,
 			Err:  err,
 		}
 	}
 	if out.KeyCount == nil || (*out.KeyCount == 0 && name != "") {
 		return nil, &os.PathError{
-			Op:   "stat",
+			Op:   opStat,
 			Path: name,
 			Err:  os.ErrNotExist,
 		}


### PR DESCRIPTION
## Summary
- `golangci-lint`'s `goconst` check flags the `"stat"` string literal in `s3_fs.go` (used 3x as `os.PathError.Op`), which has been failing the `Build` workflow on `main` since #921.
- This cascades: every open PR shows a CI failure on `build (1.25)`, including plain dependency-bump PRs that touch no Go code.
- Fix: extract the literal into a package-level `opStat` constant and use it at all three call sites.

## Test plan
- [x] `go build ./...`
- [x] `golangci-lint run` → 0 issues
- [x] `go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...` → 30/30 passed, 85.4% coverage (MinIO via docker)