### PR TITLE
feat(fs): add server-side encryption (SSE) support to UploadedFileProperties

### DIFF
--- a/s3_file.go
+++ b/s3_file.go
@@ -340,7 +340,7 @@ func (f *File) openWriteStream() error {
 		}
 
 		if f.fs.FileProps != nil {
-			applyFileWriteProps(input, f.fs.FileProps)
+			applyFileProps(input, f.fs.FileProps)
 		}
 
 		// If no Content-Type was specified, we'll guess one

--- a/s3_fs.go
+++ b/s3_fs.go
@@ -38,7 +38,15 @@ type Fs struct {
 type UploadedFileProperties struct {
 	CacheControl *string // CacheControl defines the Cache-Control header
 	ContentType  *string // ContentType define the Content-Type header
-	ACL          string  // ACL defines the right to apply
+	// SSEKMSKeyID is the KMS key ID or ARN to use when ServerSideEncryption is a KMS mode.
+	SSEKMSKeyID *string
+	// SSEKMSEncryptionContext is the base64-encoded KMS encryption context, only used
+	// when ServerSideEncryption is a KMS mode.
+	SSEKMSEncryptionContext *string
+	ACL                     string // ACL defines the right to apply
+	// ServerSideEncryption selects the encryption mode (e.g. types.ServerSideEncryptionAwsKms
+	// or types.ServerSideEncryptionAes256). Leave empty to not request encryption.
+	ServerSideEncryption types.ServerSideEncryption
 }
 
 // NewFsFromConfig creates a new Fs instance from an AWS Config
@@ -85,7 +93,7 @@ func (fs *Fs) Create(name string) (afero.File, error) {
 		}
 
 		if fs.FileProps != nil {
-			applyFileCreateProps(req, fs.FileProps)
+			applyFileProps(req, fs.FileProps)
 		}
 
 		// If no Content-Type was specified, we'll guess one
@@ -349,9 +357,9 @@ func (fs Fs) sanitize(name string) string {
 	return sanitize(name)
 }
 
-// I couldn't find a way to make this code cleaner. It's basically a big copy-paste on two
-// very similar structures.
-func applyFileCreateProps(req *s3.PutObjectInput, p *UploadedFileProperties) {
+// applyFileProps copies the user-configured properties onto a PutObjectInput, used both
+// for the initial empty object created by Create() and for the streamed multipart upload.
+func applyFileProps(req *s3.PutObjectInput, p *UploadedFileProperties) {
 	if p.ACL != "" {
 		req.ACL = types.ObjectCannedACL(p.ACL)
 	}
@@ -363,19 +371,17 @@ func applyFileCreateProps(req *s3.PutObjectInput, p *UploadedFileProperties) {
 	if p.ContentType != nil {
 		req.ContentType = p.ContentType
 	}
-}
 
-func applyFileWriteProps(input *s3.PutObjectInput, p *UploadedFileProperties) {
-	if p.ACL != "" {
-		input.ACL = types.ObjectCannedACL(p.ACL)
+	if p.ServerSideEncryption != "" {
+		req.ServerSideEncryption = p.ServerSideEncryption
 	}
 
-	if p.CacheControl != nil {
-		input.CacheControl = p.CacheControl
+	if p.SSEKMSKeyID != nil {
+		req.SSEKMSKeyId = p.SSEKMSKeyID
 	}
 
-	if p.ContentType != nil {
-		input.ContentType = p.ContentType
+	if p.SSEKMSEncryptionContext != nil {
+		req.SSEKMSEncryptionContext = p.SSEKMSEncryptionContext
 	}
 }
 

--- a/s3_test.go
+++ b/s3_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/spf13/afero"
 )
 
@@ -880,6 +881,26 @@ func TestFileProps(t *testing.T) {
 		}
 	})
 
+}
+
+// TestApplyFilePropsSSE checks the server-side-encryption fields are copied onto the
+// PutObjectInput. This can't be a round-trip test against MinIO: the CI MinIO image has
+// no KMS configured, so it rejects any PutObject that requests encryption.
+func TestApplyFilePropsSSE(t *testing.T) {
+	req := require.New(t)
+
+	props := &UploadedFileProperties{
+		ServerSideEncryption:    types.ServerSideEncryptionAwsKms,
+		SSEKMSKeyID:             aws.String("arn:aws:kms:us-east-1:111122223333:key/test-key-id"),
+		SSEKMSEncryptionContext: aws.String("eyJmb28iOiAiYmFyIn0="),
+	}
+
+	input := &s3.PutObjectInput{}
+	applyFileProps(input, props)
+
+	req.Equal(types.ServerSideEncryptionAwsKms, input.ServerSideEncryption)
+	req.Equal("arn:aws:kms:us-east-1:111122223333:key/test-key-id", *input.SSEKMSKeyId)
+	req.Equal("eyJmb28iOiAiYmFyIn0=", *input.SSEKMSEncryptionContext)
 }
 
 func TestFileReaddir(t *testing.T) {


### PR DESCRIPTION
## Summary
Closes #719.

- Adds `ServerSideEncryption`, `SSEKMSKeyID`, and `SSEKMSEncryptionContext` to `UploadedFileProperties`, applied to both the initial `PutObject` (`Create`) and the streamed multipart upload (`Write`) — mirroring how `ACL`/`CacheControl`/`ContentType` already work.
- `applyFileCreateProps` and `applyFileWriteProps` had become byte-for-byte identical once the SSE fields were added (both already took the same `*s3.PutObjectInput`), so `golangci-lint`'s `dupl` check started failing. Unified them into a single `applyFileProps` rather than re-adding the same fields twice.
- Couldn't do a full encrypted round-trip test against the CI MinIO image (it has no KMS backend configured, so any encrypted `PutObject` is rejected with `InvalidArgument: Server side encryption specified but KMS is not configured` — verified this empirically). Added a focused unit test (`TestApplyFilePropsSSE`) checking the fields land correctly on the `PutObjectInput` instead.

## Test plan
- [x] `go build ./...`, `golangci-lint run` → clean
- [x] `go test -race -coverprofile=... ./...` (MinIO) → all pass, 86.6% coverage
- [x] Confirmed MinIO's CI image rejects SSE without KMS (hence the unit-level test instead of round-trip)